### PR TITLE
Improve prun history integration diagnostics

### DIFF
--- a/src/help.ts
+++ b/src/help.ts
@@ -38,6 +38,7 @@ export async function help(argv: any[]) {
           '~ pix: npx package',
           '~ pui: uninstall package',
           '~ prun: run package script',
+          '~ prun --doctor: show shell/history diagnostics',
           '~ pinit: package init',
           '~ pbuild: go build | cargo build',
           '~ pfind: find monorepo of yarn or pnpm',

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import {
   printPkgToolStatus,
   resolvePkgTool,
 } from './pkgManager'
-import { printPrunInit, prun } from './prun'
+import { printPrunDoctor, printPrunInit, prun } from './prun'
 import { pu } from './pu'
 import { pui } from './pui'
 import { getCcommand } from './require'
@@ -148,6 +148,16 @@ export async function setup() {
 
   if ((exec === 'prun' || exec === 'prun.mjs') && argv[0] === '--init') {
     printPrunInit(argv.slice(1))
+    return
+  }
+  if (
+    (exec === 'prun'
+      || exec === 'prun.mjs'
+      || exec === 'pfind'
+      || exec === 'pfind.mjs')
+    && argv[0] === '--doctor'
+  ) {
+    printPrunDoctor()
     return
   }
 

--- a/src/prun.ts
+++ b/src/prun.ts
@@ -191,7 +191,7 @@ function getPrunInitConfig(shell: string, home: string) {
 function resolveHistoryHintPath() {
   const custom = process.env.CCOMMAND_HISTORY_HINT || ''
   if (custom)
-return custom
+    return custom
 
   const home = process.env.HOME || os.homedir()
   const cacheHome = process.env.XDG_CACHE_HOME || path.join(home, '.cache')
@@ -204,7 +204,7 @@ function yesNo(value: boolean) {
 
 function printPrunAutoInitNotice(rcFile: string, initLine: string) {
   if (!process.stdout.isTTY)
-return
+    return
   console.log(
     color.yellow(
       isZh
@@ -226,7 +226,7 @@ export function printPrunDoctor() {
       rcContent = fs.readFileSync(rcFile, 'utf8')
       rcExists = true
     }
- catch {
+    catch {
       rcExists = false
     }
   }
@@ -238,7 +238,7 @@ export function printPrunDoctor() {
     hintValue = fs.readFileSync(hintPath, 'utf8').trim()
     hintExists = true
   }
- catch {
+  catch {
     hintExists = false
   }
 

--- a/src/prun.ts
+++ b/src/prun.ts
@@ -158,35 +158,126 @@ function getPowerShellProfilePath(shell: 'powershell' | 'pwsh', home: string) {
   return path.join(configHome, 'powershell', 'Microsoft.PowerShell_profile.ps1')
 }
 
+function getPrunInitConfig(shell: string, home: string) {
+  if (shell === 'zsh') {
+    const zdotdir = process.env.ZDOTDIR || home
+    return {
+      rcFile: path.join(zdotdir, '.zshrc'),
+      initLine: 'eval "$(prun --init zsh)"',
+    }
+  }
+  if (shell === 'bash') {
+    return {
+      rcFile: path.join(home, '.bashrc'),
+      initLine: 'eval "$(prun --init bash)"',
+    }
+  }
+  if (shell === 'fish') {
+    const configHome = process.env.XDG_CONFIG_HOME || path.join(home, '.config')
+    return {
+      rcFile: path.join(configHome, 'fish', 'config.fish'),
+      initLine: 'prun --init fish | source',
+    }
+  }
+  if (shell === 'powershell' || shell === 'pwsh') {
+    return {
+      rcFile: getPowerShellProfilePath(shell, home),
+      initLine: `prun --init ${shell} | Out-String | Invoke-Expression`,
+    }
+  }
+  return null
+}
+
+function resolveHistoryHintPath() {
+  const custom = process.env.CCOMMAND_HISTORY_HINT || ''
+  if (custom)
+return custom
+
+  const home = process.env.HOME || os.homedir()
+  const cacheHome = process.env.XDG_CACHE_HOME || path.join(home, '.cache')
+  return path.join(cacheHome, 'ccommand', 'last-history')
+}
+
+function yesNo(value: boolean) {
+  return value ? 'yes' : 'no'
+}
+
+function printPrunAutoInitNotice(rcFile: string, initLine: string) {
+  if (!process.stdout.isTTY)
+return
+  console.log(
+    color.yellow(
+      isZh
+        ? `已写入 shell hook: ${rcFile}\n当前终端还未生效，请执行: ${initLine}\n或重新打开终端。`
+        : `Installed shell hook into ${rcFile}.\nThis terminal is not updated yet. Run: ${initLine}\nOr reopen the terminal.`,
+    ),
+  )
+}
+
+export function printPrunDoctor() {
+  const shell = detectShell()
+  const home = process.env.HOME || os.homedir()
+  const initConfig = getPrunInitConfig(shell, home)
+  const rcFile = initConfig?.rcFile || ''
+  let rcContent = ''
+  let rcExists = false
+  if (rcFile) {
+    try {
+      rcContent = fs.readFileSync(rcFile, 'utf8')
+      rcExists = true
+    }
+ catch {
+      rcExists = false
+    }
+  }
+
+  const hintPath = resolveHistoryHintPath()
+  let hintExists = false
+  let hintValue = ''
+  try {
+    hintValue = fs.readFileSync(hintPath, 'utf8').trim()
+    hintExists = true
+  }
+ catch {
+    hintExists = false
+  }
+
+  const lines = [
+    `shell detected: ${shell}`,
+    `hook active: ${yesNo(process.env.PRUN_HOOK_ACTIVE === '1')}`,
+    `profile path: ${rcFile || '(unsupported shell)'}`,
+    `profile exists: ${yesNo(rcExists)}`,
+    `profile contains prun --init: ${yesNo(/prun\s+--init/.test(rcContent))}`,
+    `history hint path: ${hintPath}`,
+    `last hint exists: ${yesNo(hintExists)}`,
+    `last hint value: ${hintValue || '(empty)'}`,
+    `stdin isTTY: ${yesNo(Boolean(process.stdin.isTTY))}`,
+    `stdout isTTY: ${yesNo(Boolean(process.stdout.isTTY))}`,
+    `CCOMMAND_NO_HISTORY: ${process.env.CCOMMAND_NO_HISTORY || ''}`,
+    `NO_HISTORY: ${process.env.NO_HISTORY || ''}`,
+  ]
+
+  if (shell === 'powershell' || shell === 'pwsh') {
+    lines.push(
+      `PSReadLine loaded: ${process.env.PRUN_PSREADLINE_LOADED || '(unknown)'}`,
+      `HistorySavePath: ${process.env.PRUN_PSREADLINE_HISTORY_SAVE_PATH || ''}`,
+      `HistorySaveStyle: ${process.env.PRUN_PSREADLINE_HISTORY_SAVE_STYLE || ''}`,
+    )
+  }
+
+  console.log(lines.join('\n'))
+}
+
 export function ensurePrunAutoInit() {
   if (!shouldAutoInit())
     return
   const shell = detectShell()
   const home = process.env.HOME || os.homedir()
-  let rcFile = ''
-  let initLine = ''
-
-  if (shell === 'zsh') {
-    const zdotdir = process.env.ZDOTDIR || home
-    rcFile = path.join(zdotdir, '.zshrc')
-    initLine = 'eval "$(prun --init zsh)"'
-  }
-  else if (shell === 'bash') {
-    rcFile = path.join(home, '.bashrc')
-    initLine = 'eval "$(prun --init bash)"'
-  }
-  else if (shell === 'fish') {
-    const configHome = process.env.XDG_CONFIG_HOME || path.join(home, '.config')
-    rcFile = path.join(configHome, 'fish', 'config.fish')
-    initLine = 'prun --init fish | source'
-  }
-  else if (shell === 'powershell' || shell === 'pwsh') {
-    rcFile = getPowerShellProfilePath(shell, home)
-    initLine = `prun --init ${shell} | Out-String | Invoke-Expression`
-  }
-  else {
+  const initConfig = getPrunInitConfig(shell, home)
+  if (!initConfig)
     return
-  }
+
+  const { rcFile, initLine } = initConfig
 
   try {
     const dir = path.dirname(rcFile)
@@ -197,6 +288,7 @@ export function ensurePrunAutoInit() {
     if (!/prun\s+--init/.test(content)) {
       const prefix = content.length && !content.endsWith('\n') ? '\n' : ''
       fs.appendFileSync(rcFile, `${prefix}${initLine}\n`, 'utf8')
+      printPrunAutoInitNotice(rcFile, initLine)
     }
   }
   catch {
@@ -230,6 +322,7 @@ export function printPrunInit(args: string[] = []) {
 
   if (shell === 'zsh') {
     script = [
+      'export PRUN_HOOK_ACTIVE=1',
       'prun() {',
       `  local bin=${bin}`,
       '  local -a cmd',
@@ -288,6 +381,7 @@ export function printPrunInit(args: string[] = []) {
   }
   else if (shell === 'bash') {
     script = [
+      'export PRUN_HOOK_ACTIVE=1',
       'prun() {',
       `  local bin=${bin}`,
       '  local -a cmd',
@@ -350,6 +444,7 @@ export function printPrunInit(args: string[] = []) {
   }
   else if (shell === 'fish') {
     script = [
+      'set -gx PRUN_HOOK_ACTIVE 1',
       'function prun',
       `  set -l bin ${bin}`,
       '  set -l cmd (string split -- " " $bin)',
@@ -387,6 +482,20 @@ export function printPrunInit(args: string[] = []) {
     const powerShellBin = splitCommand(binArg).map(powerShellQuote).join(', ')
     script = [
       `$script:__prun_bin = @(${powerShellBin || powerShellQuote('prun')})`,
+      '$env:PRUN_HOOK_ACTIVE = "1"',
+      'try {',
+      '  $option = Get-PSReadLineOption -ErrorAction SilentlyContinue',
+      '  if ($option) {',
+      '    $env:PRUN_PSREADLINE_LOADED = "yes"',
+      '    $env:PRUN_PSREADLINE_HISTORY_SAVE_PATH = "$($option.HistorySavePath)"',
+      '    $env:PRUN_PSREADLINE_HISTORY_SAVE_STYLE = "$($option.HistorySaveStyle)"',
+      '  }',
+      '  else {',
+      '    $env:PRUN_PSREADLINE_LOADED = "no"',
+      '  }',
+      '} catch {',
+      '  $env:PRUN_PSREADLINE_LOADED = "no"',
+      '}',
       '',
       'function global:prun {',
       '  param([Parameter(ValueFromRemainingArguments = $true)] [string[]] $CliArgs)',
@@ -404,6 +513,41 @@ export function printPrunInit(args: string[] = []) {
       '    $extra = $script:__prun_bin[1..($script:__prun_bin.Count - 1)]',
       '  }',
       '  & $command @extra @CliArgs',
+      '}',
+      '',
+      'function global:__prun_add_history {',
+      '  param([string] $Command)',
+      '  $added = $false',
+      '',
+      '  try {',
+      '    $psReadLineType = "Microsoft.PowerShell.PSConsoleReadLine" -as [type]',
+      '    if ($null -ne $psReadLineType) {',
+      '      $psReadLineType::AddToHistory($Command)',
+      '      $added = $true',
+      '    }',
+      '  } catch {}',
+      '',
+      '  try {',
+      '    $option = Get-PSReadLineOption -ErrorAction SilentlyContinue',
+      '    if ($option -and $option.HistorySavePath -and ($option.HistorySaveStyle -ne "SaveNothing")) {',
+      '      $path = $option.HistorySavePath',
+      '      $dir = Split-Path -Parent $path',
+      '      if ($dir -and -not (Test-Path -LiteralPath $dir)) {',
+      '        New-Item -ItemType Directory -Path $dir -Force | Out-Null',
+      '      }',
+      '',
+      '      $last = $null',
+      '      if (Test-Path -LiteralPath $path) {',
+      '        $last = Get-Content -LiteralPath $path -Tail 1 -ErrorAction SilentlyContinue',
+      '      }',
+      '',
+      '      if ($last -ne $Command) {',
+      '        Add-Content -LiteralPath $path -Value $Command -Encoding utf8',
+      '      }',
+      '    }',
+      '  } catch {}',
+      '',
+      '  return $added',
       '}',
       '',
       'function global:__prun_sync_history {',
@@ -445,11 +589,7 @@ export function printPrunInit(args: string[] = []) {
       '    return',
       '  }',
       '  $script:__PRUN_HISTORY_HINT_TS = $hintTs',
-      '  $psReadLineType = "Microsoft.PowerShell.PSConsoleReadLine" -as [type]',
-      '  if ($null -eq $psReadLineType) {',
-      '    return',
-      '  }',
-      '  $psReadLineType::AddToHistory($hintCmd)',
+      '  [void](__prun_add_history $hintCmd)',
       '}',
       '',
       'if (-not $script:__PRUN_PROMPT_INSTALLED) {',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -42,6 +42,12 @@ vi.mock('../src/pkgManager', () => ({
 
 const originalArgv = process.argv
 
+function binPath(name: string) {
+  return process.platform === 'win32'
+    ? `C:\\tools\\${name}.cmd`
+    : `/usr/local/bin/${name}`
+}
+
 beforeEach(() => {
   vi.resetModules()
   help.mockResolvedValue(undefined)
@@ -73,21 +79,21 @@ afterEach(() => {
 
 describe('setup command guard', () => {
   it('does not run deps for pbuild in node projects', async () => {
-    process.argv = ['node', '/usr/local/bin/pbuild', 'arg1']
+    process.argv = ['node', binPath('pbuild'), 'arg1']
     const { setup } = await import('../src/index')
     await expect(setup()).resolves.toBeUndefined()
     expect(installDeps).not.toHaveBeenCalled()
   })
 
   it('does not run deps for unknown commands', async () => {
-    process.argv = ['node', '/usr/local/bin/punknown', 'arg1']
+    process.argv = ['node', binPath('punknown'), 'arg1']
     const { setup } = await import('../src/index')
     await expect(setup()).resolves.toBeUndefined()
     expect(installDeps).not.toHaveBeenCalled()
   })
 
   it('shows the current package-manager status without running installs', async () => {
-    process.argv = ['node', '/usr/local/bin/pi', '--show-tool']
+    process.argv = ['node', binPath('pi'), '--show-tool']
     const { setup } = await import('../src/index')
     await expect(setup()).resolves.toBeUndefined()
     expect(getPkgToolStatus).toHaveBeenCalledTimes(1)
@@ -102,7 +108,7 @@ describe('setup command guard', () => {
   })
 
   it('shows the current package-manager status as json', async () => {
-    process.argv = ['node', '/usr/local/bin/pi', '--show-tool', '--json']
+    process.argv = ['node', binPath('pi'), '--show-tool', '--json']
     const { setup } = await import('../src/index')
     await expect(setup()).resolves.toBeUndefined()
     expect(getPkgToolStatus).toHaveBeenCalledTimes(1)
@@ -117,7 +123,7 @@ describe('setup command guard', () => {
   })
 
   it('passes an explicit tool choice through to package-manager resolution', async () => {
-    process.argv = ['node', '/usr/local/bin/pi', '--choose-tool', 'bun']
+    process.argv = ['node', binPath('pi'), '--choose-tool', 'bun']
     const { setup } = await import('../src/index')
     await expect(setup()).resolves.toBeUndefined()
     expect(process.env.PI_PREFERRED_TOOL).toBe('bun')
@@ -125,7 +131,7 @@ describe('setup command guard', () => {
   })
 
   it('lists candidate tools without running installs', async () => {
-    process.argv = ['node', '/usr/local/bin/pi', '--list-tools', '--json']
+    process.argv = ['node', binPath('pi'), '--list-tools', '--json']
     const { setup } = await import('../src/index')
     await expect(setup()).resolves.toBeUndefined()
     expect(getPkgToolStatus).toHaveBeenCalledTimes(1)

--- a/test/prun-init.test.ts
+++ b/test/prun-init.test.ts
@@ -18,7 +18,7 @@ describe('printPrunInit', () => {
     expect(script).toContain('history -s -- "$hint_cmd"')
   })
 
-  it('emits a PowerShell prompt hook that re-adds the selected command to PSReadLine history', () => {
+  it('emits a PowerShell prompt hook with PSReadLine and file history fallback', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
     printPrunInit(['powershell'])
@@ -26,8 +26,11 @@ describe('printPrunInit', () => {
     const script = logSpy.mock.calls[0]?.[0]
     expect(script).toContain('function global:prun')
     expect(script).toContain('function global:__prun_sync_history')
+    expect(script).toContain('function global:__prun_add_history')
     expect(script).toContain('PSConsoleReadLine')
-    expect(script).toContain('AddToHistory($hintCmd)')
+    expect(script).toContain('AddToHistory($Command)')
+    expect(script).toContain('HistorySavePath')
+    expect(script).toContain('[void](__prun_add_history $hintCmd)')
     expect(script).toContain('function global:prompt')
   })
 

--- a/test/resolvePkgTool.test.ts
+++ b/test/resolvePkgTool.test.ts
@@ -18,9 +18,13 @@ vi.mock('../src/tty', () => ({
 
 const originalCwd = process.cwd()
 const originalConfigHome = process.env.XDG_CONFIG_HOME
+const originalAppData = process.env.APPDATA
 
 async function createTempWorkspace() {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-resolve-tool-'))
+  const configHome = path.join(dir, '.config')
+  process.env.XDG_CONFIG_HOME = configHome
+  process.env.APPDATA = configHome
   return dir
 }
 
@@ -48,6 +52,10 @@ afterEach(() => {
     delete process.env.XDG_CONFIG_HOME
   else
     process.env.XDG_CONFIG_HOME = originalConfigHome
+  if (originalAppData == null)
+    delete process.env.APPDATA
+  else
+    process.env.APPDATA = originalAppData
 })
 
 describe('resolvePkgTool', () => {


### PR DESCRIPTION
## Summary
- add PowerShell history fallback through PSReadLine HistorySavePath when AddToHistory is unavailable or insufficient
- show a one-time activation notice after auto-installing the prun shell hook
- add prun --doctor / pfind --doctor shell/history diagnostics and hook-active markers
- include PSReadLine diagnostics from the PowerShell hook environment

## Related
- Depends on / complements ccommand picker/history changes: https://github.com/Simon-He95/ccommand/pull/62

## Verification
- git diff --check -- src/prun.ts src/index.ts src/help.ts
- tsc --noEmit --skipLibCheck --target es2022 --module ESNext --moduleResolution Bundler src/prun.ts
- generated pwsh init script contains PRUN_HOOK_ACTIVE, __prun_add_history, and HistorySavePath fallback

Note: full project-level commands are blocked in the current local worktree because package.json/tsconfig.json are already deleted outside this change.