### PR TITLE
fix: flush terminal-restore writes before exiting on cancel

### DIFF
--- a/src/pil.ts
+++ b/src/pil.ts
@@ -2,7 +2,7 @@ import process from 'node:process'
 import { getPkg } from 'lazy-js-utils/node'
 import pc from 'picocolors'
 import { pi } from './pi'
-import { isInteractive, ttyMultiSelect } from './tty'
+import { exitWithFlush, isInteractive, ttyMultiSelect } from './tty'
 import { getParams } from './utils'
 // install @latest
 export async function pil(params: string) {
@@ -39,7 +39,7 @@ export async function pil(params: string) {
 
     if (!choose || choose.length === 0) {
       console.log(pc.dim('已取消'))
-      process.exit(0)
+      await exitWithFlush(0)
     }
     const names = choose!.map((i: string) => {
       const name = i.split(': ')[0]

--- a/src/pkgManager.ts
+++ b/src/pkgManager.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 import { isFile } from 'lazy-js-utils'
 import { getPkgTool } from 'lazy-js-utils/node'
 import colors from 'picocolors'
-import { isInteractive, ttySelect } from './tty'
+import { exitWithFlush, isInteractive, ttySelect } from './tty'
 
 export type PkgTool = string
 export type PkgToolResolutionSource
@@ -643,7 +643,7 @@ export async function resolvePkgTool(options: ResolvePkgToolOptions = {}): Promi
     }
     if (selection.status === 'cancelled') {
       console.log(colors.dim(isZh ? '已取消' : 'Cancelled'))
-      process.exit(0)
+      await exitWithFlush(0)
     }
 
     const tool = getDetectedToolFallback(detected, candidates)

--- a/src/pui.ts
+++ b/src/pui.ts
@@ -2,7 +2,7 @@ import process from 'node:process'
 import { getPkg, useNodeWorker } from 'lazy-js-utils/node'
 import colors from 'picocolors'
 import { getRemoveCommand, resolvePkgTool } from './pkgManager'
-import { isInteractive, ttySelect } from './tty'
+import { exitWithFlush, isInteractive, ttySelect } from './tty'
 import { loading } from './utils'
 
 const isZh = process.env.PI_Lang === 'zh'
@@ -41,7 +41,7 @@ export async function pui(params: string, pkg: string) {
     )
     if (!choose) {
       console.log(colors.dim('已取消'))
-      process.exit(0)
+      await exitWithFlush(0)
     }
     pkg = params = choose!.split(': ')[0]
   }

--- a/src/tty.ts
+++ b/src/tty.ts
@@ -416,7 +416,14 @@ async function runSelect(options: string[], config: SelectConfig) {
         readline.cursorTo(stdout, 0)
       readline.clearScreenDown(stdout)
       stdout.write('\n')
-      resolve(value)
+      // Flush the terminal-restore writes before resolving: callers may call
+      // process.exit() right away, and hard exits can drop queued TTY writes
+      // on Windows (ConPTY), leaving the terminal in a broken state (hidden
+      // cursor, stale screen) and making subsequent shell input laggy.
+      const flushed = () => resolve(value)
+      stdout.write('', flushed)
+      const timer = setTimeout(flushed, 200)
+      timer.unref?.()
     }
 
     const confirmSelection = () => {
@@ -563,6 +570,30 @@ export async function ttyMultiSelect(options: string[], placeholder: string) {
     mode: 'multiple',
   })
   return Array.isArray(result) ? result : null
+}
+
+/**
+ * Exit after queued terminal output (cancel messages, cursor/mouse restore
+ * sequences) has been flushed. A plain process.exit() can drop queued TTY
+ * writes on Windows (ConPTY), leaving the terminal in a broken state.
+ * Resolves as `never`: always await it so no code runs after the exit.
+ */
+export async function exitWithFlush(code = 0): Promise<never> {
+  const stdout = process.stdout
+  if (stdout.writableLength > 0) {
+    await new Promise<void>((resolve) => {
+      const flushed = () => resolve()
+      try {
+        stdout.write('', flushed)
+      }
+      catch {
+        return resolve()
+      }
+      const timer = setTimeout(flushed, 200)
+      timer.unref?.()
+    })
+  }
+  process.exit(code)
 }
 
 export function renderBox(


### PR DESCRIPTION
## Problem

On Windows PowerShell, cancelling an interactive selection (e.g. `pfind`/package-manager pickers) leaves the terminal input super laggy — typing several characters before one appears. Root cause analysis in ccommand: https://github.com/Simon-He95/ccommand/pull/69

## Fix

pi's own pickers have the same pattern: terminal-restore writes are queued and then the cancel path calls `process.exit()` immediately, which can drop the writes on Windows ConPTY.

- `tty.ts`: `done()` waits for stdout to flush before resolving the picker promise
- `tty.ts`: new `exitWithFlush(code)` helper — exits only after queued output drains (200ms unref fallback)
- `pil.ts` / `pui.ts` / `pkgManager.ts`: cancel paths now `await exitWithFlush(0)`

## Verification

- build / lint / 45 tests pass
- pty smoke test: Esc cancel restores the cursor (`\x1B[?25h`) and flushes output before exiting with code 130